### PR TITLE
Improve validation and error messaging

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -1,0 +1,22 @@
+class TwitterError extends Error {
+  constructor(responseBody) {
+    const body = JSON.parse(responseBody);
+    let message, code;
+    if (!Array.isArray(body.errors)) {
+      message = body || 'Unknown error';
+    } else {
+      message = body.errors[0].message;
+      code = body.errors[0].code;
+    }
+
+    super(`${message}` + (code ? ` (Twitter code: ${code})` : ''));
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+class WebhookURIError extends TwitterError {}
+class UserSubscriptionError extends TwitterError {}
+class TooManySubscriptionsError extends Error {}
+
+module.exports = { TwitterError, WebhookURIError, UserSubscriptionError, TooManySubscriptionsError };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
### Problem

Most error messages in Autohook are generic; they don't explain in detail what's going on, and don't offer pointers to a solution. Furthermore, errors coming as a result of a non-successful API response are not relayed to the user.

Some of these errors can be avoided by adding client side validation and parsing (for example, to ensure a webhook URL is formally correct before registering it with Twitter).

### Solution

- Add client side validation for URL, so that an invalid URL will cause Autohook to fail before issuing an API request
- Trim whitespace from configuration variables, so that leading and/or trailing whitespaces will not cause an API request to fail
- The Autohook constructor ensures that all the required variables are set
- Add new error types so Autohook can throw separate exceptions for client side and server side errors