### PR TITLE
Improve error messaging to better flag rate limits and unknown errors

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -1,6 +1,6 @@
 class TwitterError extends Error {
-  constructor(responseBody) {
-    const body = JSON.parse(responseBody);
+  constructor(response) {
+    const body = JSON.parse(response.body);
     let message, code;
     if (!Array.isArray(body.errors)) {
       message = body || 'Unknown error';
@@ -9,7 +9,7 @@ class TwitterError extends Error {
       code = body.errors[0].code;
     }
 
-    super(`${message}` + (code ? ` (Twitter code: ${code})` : ''));
+    super(`${message}` + (code ? ` (HTTP status: ${response.statusCode}, Twitter code: ${code})` : ''));
     this.name = this.constructor.name;
     Error.captureStackTrace(this, this.constructor);
   }
@@ -17,6 +17,32 @@ class TwitterError extends Error {
 
 class WebhookURIError extends TwitterError {}
 class UserSubscriptionError extends TwitterError {}
+class RateLimitError extends Error {
+  constructor(response) {
+    const body = JSON.parse(response.body);
+    let message, code;
+    if (!Array.isArray(body.errors)) {
+      message = body || 'Unknown error';
+    } else {
+      message = body.errors[0].message;
+      code = body.errors[0].code;
+    }
+
+    const requestAllowed = response.headers['x-rate-limit-limit'];
+    const resetAt = response.headers['x-rate-limit-reset'] * 1000 - (new Date().getTime());
+    const resetAtMin = Math.round(resetAt / 60 / 1000);
+    super(`You exceeded the rate limit for ${response.req.path} (${requestAllowed} requests available, 0 remaining). Wait ${resetAtMin} minutes before trying again.`);
+    this.resetAt = response.headers['x-rate-limit-reset'] * 1000;
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
 class TooManySubscriptionsError extends Error {}
 
-module.exports = { TwitterError, WebhookURIError, UserSubscriptionError, TooManySubscriptionsError };
+module.exports = { 
+  TwitterError, 
+  WebhookURIError, 
+  UserSubscriptionError, 
+  TooManySubscriptionsError,
+  RateLimitError,
+};

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const getSubscriptionsCount = async (auth) => {
     case 200:
       break;
     case 429:
-      throw new RateLimimitError(response);
+      throw new RateLimitError(response);
       break;
     default:
       throw new TwitterError(response);
@@ -99,7 +99,7 @@ const getWebhooks = async (auth, env) => {
     case 200:
       break;
     case 429:
-      throw new RateLimimitError(response);
+      throw new RateLimitError(response);
       break;
     default:
       throw new URIError([
@@ -132,7 +132,7 @@ const deleteWebhooks = async (webhooks, auth, env) => {
       case 204:
         break;
       case 429:
-        throw new RateLimimitError(response);
+        throw new RateLimitError(response);
         break;
       default:
         throw new URIError([
@@ -179,7 +179,7 @@ const setWebhook = async (webhookUrl, auth, env) => {
      throw new WebhookURIError(response);
      return null;
     case 429:
-      throw new RateLimimitError(response);
+      throw new RateLimitError(response);
       return null;
     default:
       throw new URIError([

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const {
   TooManySubscriptionsError,
   UserSubscriptionError,
   WebhookURIError,
+  RateLimitError,
 } = require('./errors');
 
 require('dotenv').config({path: path.resolve(os.homedir(), '.env.twitter')});
@@ -62,6 +63,17 @@ const getSubscriptionsCount = async (auth) => {
   };
 
   const response = await get(requestConfig);
+
+  switch (response.statusCode) {
+    case 200:
+      break;
+    case 429:
+      throw new RateLimimitError(response);
+      break;
+    default:
+      throw new TwitterError(response);
+  }
+
   _getSubscriptionsCount = JSON.parse(response.body);
   return _getSubscriptionsCount;
 }
@@ -82,11 +94,18 @@ const getWebhooks = async (auth, env) => {
   }
 
   const response = await get(requestConfig);
-  if (response.statusCode !== 200) {
-    throw new URIError([
+
+  switch (response.statusCode) {
+    case 200:
+      break;
+    case 429:
+      throw new RateLimimitError(response);
+      break;
+    default:
+      throw new URIError([
       `Cannot get webhooks. Please check that '${env}' is a valid environment defined in your`,
       `Developer dashboard at https://developer.twitter.com/en/account/environments, and that`,
-      `your OAuth credentials are valid and can access '${env}'.`].join(' '));
+      `your OAuth credentials are valid and can access '${env}'. (HTTP status: ${response.statusCode})`].join(' '));
   }
 
   try {
@@ -107,6 +126,20 @@ const deleteWebhooks = async (webhooks, auth, env) => {
 
     console.log(`Removing ${url}…`);
     await del(requestConfig);
+  
+    switch (response.statusCode) {
+      case 200:
+      case 204:
+        break;
+      case 429:
+        throw new RateLimimitError(response);
+        break;
+      default:
+        throw new URIError([
+        `Cannot get webhooks. Please check that '${env}' is a valid environment defined in your`,
+        `Developer dashboard at https://developer.twitter.com/en/account/environments, and that`,
+        `your OAuth credentials are valid and can access '${env}'. (HTTP status: ${response.statusCode})`].join(' '));
+    }
   }
 }
 
@@ -137,13 +170,26 @@ const setWebhook = async (webhookUrl, auth, env) => {
   }
 
   const response = await post(requestConfig);
-  const body = JSON.parse(response.body);
 
-  if (body.errors) {
-    throw new WebhookURIError(response.body);
-    return null;
+  switch (response.statusCode) {
+    case 200:
+    case 204:
+      break;
+    case 403:
+     throw new WebhookURIError(response);
+     return null;
+    case 429:
+      throw new RateLimimitError(response);
+      return null;
+    default:
+      throw new URIError([
+      `Cannot get webhooks. Please check that '${env}' is a valid environment defined in your`,
+      `Developer dashboard at https://developer.twitter.com/en/account/environments, and that`,
+      `your OAuth credentials are valid and can access '${env}'. (HTTP status: ${response.statusCode})`].join(' '));
+      return null;
   }
 
+  const body = JSON.parse(response.body);
   return body;
 }
 
@@ -157,7 +203,7 @@ const verifyCredentials = async (auth) => {
   if (response.statusCode === 200) {
     return JSON.parse(response.body).screen_name;
   } else {
-    throw new UserSubscriptionError(response.body);
+    throw new UserSubscriptionError(response);
     return null;
   }
 }
@@ -268,7 +314,7 @@ class Autohook extends EventEmitter {
       console.log(`Subscribed to ${screen_name}'s activities.`);
       updateSubscriptionCount(1);
     } else {
-      throw new UserSubscriptionError(response.body);
+      throw new UserSubscriptionError(response);
       return;
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "main": "index.js",
   "bin": {

--- a/test/listen.js
+++ b/test/listen.js
@@ -91,9 +91,14 @@ async function sayHi(event, oauth) {
   }
 
   const message = event.direct_message_events.shift();
+
+  // Filter out empty messages or non-message events
+  if (typeof message === 'undefined' || typeof message.message_create === 'undefined') {
+    return;
+  }
  
   // Filter out messages created by the the authenticating users (to avoid sending messages to oneself)
-  if (message.message_create.sender_id === oauth.user_id) {
+  if (message.message_create.sender_id === message.message_create.target.recipient_id) {
     return;
   }
 
@@ -152,6 +157,18 @@ async function sayHi(event, oauth) {
       env: process.env.TWITTER_WEBHOOK_ENV});
 
     webhook.on('event', async (event) => {
+      await sayHi(event, {
+        oauth_token: userToMonitor.oauth_token,
+        oauth_token_secret: userToMonitor.oauth_token_secret,
+        user_id: userToMonitor.user_id,
+        consumer_key: process.env.TWITTER_CONSUMER_KEY,
+        consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
+        reset: true,
+      });
+    });
+
+    webhook.on('event', async (event) => {
+      console.log('We received an event!');
       await sayHi(event, {
         oauth_token: userToMonitor.oauth_token,
         oauth_token_secret: userToMonitor.oauth_token_secret,


### PR DESCRIPTION
### Problems

- Autohook handles rate limit errors are generic `WebhookURIErrors`, which is misleading for the end user.
- The error handling logic for Twitter API responses is poor and largely inconsistent across functions.

### Solutions

- Add a new `RateLimitError`, which throws on HTTP 429 and describes how many requests were allotted and when the rate limit window will reset. This error type also exposes a `resetAt` property, containing a UNIX timestamp (in milliseconds) indicating the time when the rate limit is reset (`new Date().getTime() - RateLimitError.resetAt` gives the number of seconds the user needs to wait before being able to make another request).
- Refactor the error handling logic to consistently throw on non-2xx status codes, and to acknowledge more HTTP status codes than before.
- Refactor `TwitterError` so it can now include the HTTP status code together with the Twitter error code.