### PR TITLE
Specify repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "twitter-autohook",
   "version": "1.2.1",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/twitterdev/autohook"
+  },
   "main": "index.js",
   "bin": {
     "autohook": "./cli.js"


### PR DESCRIPTION
### Problem

Currently, have to manually search to find the github repo (instead of being able to click from NPM registry)
![Screen Shot 2019-10-21 at 11 47 46 AM](https://user-images.githubusercontent.com/3058939/67233877-e622f380-f3f8-11e9-9355-ac282b2ccf9a.png)


### Solution

Specify the repository path

### Result

Will be able to access Github repo directly from NPM