### PR TITLE
v1.3.0

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -28,10 +28,15 @@ class RateLimitError extends Error {
       code = body.errors[0].code;
     }
 
-    const requestAllowed = response.headers['x-rate-limit-limit'];
-    const resetAt = response.headers['x-rate-limit-reset'] * 1000 - (new Date().getTime());
-    const resetAtMin = Math.round(resetAt / 60 / 1000);
-    super(`You exceeded the rate limit for ${response.req.path} (${requestAllowed} requests available, 0 remaining). Wait ${resetAtMin} minutes before trying again.`);
+    if ('x-rate-limit-limit' in response.headers && 'x-rate-limit-reset' in response.headers) {
+      const requestAllowed = response.headers['x-rate-limit-limit'];
+      const resetAt = response.headers['x-rate-limit-reset'] * 1000 - (new Date().getTime());
+      const resetAtMin = Math.round(resetAt / 60 / 1000);
+      super(`You exceeded the rate limit for ${response.req.path} (${requestAllowed} requests available, 0 remaining). Wait ${resetAtMin} minutes before trying again.`);      
+    } else {
+      super(`You exceeded the rate limit for ${response.req.path}. Wait until rate limit resets and try again.`);
+    }
+
     this.resetAt = response.headers['x-rate-limit-reset'] * 1000;
     this.name = this.constructor.name;
     Error.captureStackTrace(this, this.constructor);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "repository": {
     "type": "git",

--- a/test/listen.js
+++ b/test/listen.js
@@ -1,4 +1,4 @@
-const {Autohook, setWebhook, validateWebhook} = require('..');
+const {Autohook} = require('..');
 
 const qs = require('querystring');
 const request = require('request');

--- a/test/standalone-server.js
+++ b/test/standalone-server.js
@@ -1,4 +1,4 @@
-const {Autohook, setWebhook, validateWebhook} = require('..');
+const {Autohook, validateWebhook} = require('..');
 
 const url = require('url');
 const ngrok = require('ngrok');
@@ -14,7 +14,9 @@ const startServer = (port, auth) => http.createServer((req, res) => {
   }
 
   if (route.query.crc_token) {
-    return validateWebhook(route.query.crc_token, auth, res);
+    const crc = validateWebhook(route.query.crc_token, auth, res);
+    res.writeHead(200, {'content-type': 'application/json'});
+    res.end(JSON.stringify(crc));
   }
 
   if (req.method === 'POST' && req.headers['content-type'] === 'application/json') {
@@ -49,7 +51,7 @@ const startServer = (port, auth) => http.createServer((req, res) => {
 
     const webhook = new Autohook(config);
     await webhook.removeWebhooks();
-    await setWebhook(url, config, config.env);
+    await webhook.start(webhookURL);
     await webhook.subscribe({
       oauth_token: config.token,
       oauth_token_secret: config.token_secret,


### PR DESCRIPTION
This version provides an easier way to setup a standalone server. It also fixes a few issues.

### What's new
- `validateWebhook()` assumed you had a Node.js HTTP server running, and sent the CRC response directly to that server. Because it may not always be the case, we changed it to just return a CRC signature, which you can send with your favorite server.

- You don't need to call the standalone `setWebhook()` if you already have a webhook. Just call `Autohook.start(WEBHOOK_URL)` instead.

### What's fixed
- Sometimes Twitter does not return rate limit information in the headers. `RateLimitError` now accounts for this.