### PR TITLE
Add unsubscribe method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Problem

Autohook allows to subscribe to account activity, and can enumerate the current subscriptions, but there is no method to remove an account from a webhook.

### Solution

This change will add an `unsubscribe` method to stop subscribing to a user's account activity. This is a wrapper over Account Activity API's `/1.1/account_activity/all/:env/subscriptions/:id` endpoint.