### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ autohook \
   --token $TWITTER_ACCESS_TOKEN \
   --secret $TWITTER_ACCESS_TOKEN_SECRET \
   --consumer-key $TWITTER_CONSUMER_KEY \
-  --consumer-sercret $TWITTER_CONSUMER_SECRET \
+  --consumer-secret $TWITTER_CONSUMER_SECRET \
   --env $TWITTER_WEBHOOK_ENV
 ```
 


### PR DESCRIPTION
Fixed a typo in the CLI command of the readme

### Problem

small typo in README.md

CLI command `consumer_sercret` -> `consumer_secret`

### Solution

Fixed typo in README.md

### Result


