### PR TITLE
Expose error properties in error object

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -4,6 +4,7 @@ class TwitterError extends Error {
     let message, code;
     if (!Array.isArray(body.errors)) {
       message = body || 'Unknown error';
+      code = -1;
     } else {
       message = body.errors[0].message;
       code = body.errors[0].code;
@@ -11,6 +12,8 @@ class TwitterError extends Error {
 
     super(`${message}` + (code ? ` (HTTP status: ${response.statusCode}, Twitter code: ${code})` : ''));
     this.name = this.constructor.name;
+    this.code = code;
+    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }
@@ -23,6 +26,7 @@ class RateLimitError extends Error {
     let message, code;
     if (!Array.isArray(body.errors)) {
       message = body || 'Unknown error';
+      code = -1;
     } else {
       message = body.errors[0].message;
       code = body.errors[0].code;
@@ -39,6 +43,8 @@ class RateLimitError extends Error {
 
     this.resetAt = response.headers['x-rate-limit-reset'] * 1000;
     this.name = this.constructor.name;
+    this.code = code;
+    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/errors/index.js
+++ b/errors/index.js
@@ -13,7 +13,6 @@ class TwitterError extends Error {
     super(`${message}` + (code ? ` (HTTP status: ${response.statusCode}, Twitter code: ${code})` : ''));
     this.name = this.constructor.name;
     this.code = code;
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }
@@ -44,7 +43,6 @@ class RateLimitError extends Error {
     this.resetAt = response.headers['x-rate-limit-reset'] * 1000;
     this.name = this.constructor.name;
     this.code = code;
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "repository": {
     "type": "git",

--- a/test/errors.js
+++ b/test/errors.js
@@ -5,39 +5,41 @@ const {
   RateLimitError,
 } = require('../errors');
 const response = {
-  body: {
-    errors: [{
-      message: 'test error',
-      code: 1337,
-    }],
-  }
+  statusCode: 200,
+  body: JSON.stringify({
+      errors: [{
+        message: 'test error',
+        code: 1337,
+      }],
+    }),
+  req: {
+    path: '/example',
+  },
+  headers: {
+  'x-rate-limit-reset': new Date().getTime(),
+}
 };
-
-const body = JSON.stringify(response.body);
 
 const assert = (e) => {
   console.log(`Trowing ${e.name}`);
-  console.log(e.message === 'test error');
+
+  console.log(e.message === `test error (HTTP status: 200, Twitter code: 1337)`);
   console.log(e.code === 1337);
 }
 try {
-  throw new TwitterError({body: body}); 
+  throw new TwitterError(response); 
 } catch(e) {
   assert(e);
 }
 
 try {
-  throw new UserSubscriptionError({
-    body: body, 
-    headers: {
-    'x-rate-limit-reset': new Date().getTime(),
-  }}); 
+  throw new UserSubscriptionError(response); 
 } catch(e) {
   assert(e);
 }
 
 try {
-  throw new WebhookURIError({body: body}); 
+  throw new WebhookURIError(response); 
 } catch(e) {
   assert(e);
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,43 @@
+const {
+  TwitterError,
+  UserSubscriptionError,
+  WebhookURIError,
+  RateLimitError,
+} = require('../errors');
+const response = {
+  body: {
+    errors: [{
+      message: 'test error',
+      code: 1337,
+    }],
+  }
+};
+
+const body = JSON.stringify(response.body);
+
+const assert = (e) => {
+  console.log(`Trowing ${e.name}`);
+  console.log(e.message === 'test error');
+  console.log(e.code === 1337);
+}
+try {
+  throw new TwitterError({body: body}); 
+} catch(e) {
+  assert(e);
+}
+
+try {
+  throw new UserSubscriptionError({
+    body: body, 
+    headers: {
+    'x-rate-limit-reset': new Date().getTime(),
+  }}); 
+} catch(e) {
+  assert(e);
+}
+
+try {
+  throw new WebhookURIError({body: body}); 
+} catch(e) {
+  assert(e);
+}

--- a/test/errors.js
+++ b/test/errors.js
@@ -22,8 +22,12 @@ const response = {
 
 const assert = (e) => {
   console.log(`Trowing ${e.name}`);
-
-  console.log(e.message === `test error (HTTP status: 200, Twitter code: 1337)`);
+  if (e instanceof RateLimitError) {
+    console.log(e.message === 'You exceeded the rate limit for /example. Wait until rate limit resets and try again.');
+  } else {
+    console.log(e.message === `test error (HTTP status: 200, Twitter code: 1337)`);  
+  }
+  
   console.log(e.code === 1337);
 }
 try {
@@ -40,6 +44,12 @@ try {
 
 try {
   throw new WebhookURIError(response); 
+} catch(e) {
+  assert(e);
+}
+
+try {
+  throw new RateLimitError(response); 
 } catch(e) {
   assert(e);
 }


### PR DESCRIPTION
### Problem

The error objects do not expose messages and codes received from the Twitter API. As a result, it's currently impossible to determine the cause of a specific `TwitterError`, unless the user catches and then parses the error message.

### Solution

This PR expose two new properties in `TwitterError` (and related subclasses):
- `TwitterError.message` is the error message (as generated by the error class)
- `TwitterError.code` is the error code received from the Twitter API

### Result

Autohook users should be able to use and reference the properties as illustrated in the test case (`test/errors.js`).