### PR TITLE
Add URL module and fix error messages in CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -44,9 +44,9 @@ const subscribe = async (auth) => {
   try {
     webhook.subscribe(auth);
   } catch(e) {
-    switch (e.constructor.name) {
-      case UserSubscriptionError.name:
-        console.error(e.getMessage());
+    switch (e.constructor) {
+      case UserSubscriptionError:
+        console.error(e.message);
         break;        
     }
 
@@ -64,15 +64,15 @@ const subscribe = async (auth) => {
   try {
     await webhook.start(argv.webhookUrl || null);  
   } catch(e) {
-    switch (e.constructor.name) {
-      case TooManyWebhooksError.name:
+    switch (e.constructor) {
+      case TooManyWebhooksError:
         console.error('Cannot add webhook: you have exceeded the number of webhooks available', 
           `to you for the '${argv.env || process.env.TWITTER_WEBHOOK_ENV}' environment.`,
           `Use 'autohook -r' to remove your existing webhooks or remove callbacks manually`,
           'using the Twitter API.');
         break;
       default:
-        console.error('Error:', e.getMessage()); 
+        console.error('Error:', e.message); 
         break;        
     }
 

--- a/errors/index.js
+++ b/errors/index.js
@@ -46,7 +46,7 @@ class RateLimitError extends Error {
     Error.captureStackTrace(this, this.constructor);
   }
 }
-class TooManySubscriptionsError extends Error {}
+class TooManySubscriptionsError extends TwitterError {}
 
 module.exports = { 
   TwitterError, 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const crypto = require('crypto');
 const path = require('path');
 const os = require('os');
 const EventEmitter = require('events');
+const URL = require('url').URL;
+
 const {
   TooManySubscriptionsError,
   UserSubscriptionError,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "repository": {
     "type": "git",

--- a/test/errors.js
+++ b/test/errors.js
@@ -3,6 +3,7 @@ const {
   UserSubscriptionError,
   WebhookURIError,
   RateLimitError,
+  TooManySubscriptionsError,
 } = require('../errors');
 const response = {
   statusCode: 200,
@@ -30,6 +31,7 @@ const assert = (e) => {
   
   console.log(e.code === 1337);
 }
+
 try {
   throw new TwitterError(response); 
 } catch(e) {
@@ -50,6 +52,12 @@ try {
 
 try {
   throw new RateLimitError(response); 
+} catch(e) {
+  assert(e);
+}
+
+try {
+  throw new TooManySubscriptionsError(response); 
 } catch(e) {
   assert(e);
 }

--- a/test/listen.js
+++ b/test/listen.js
@@ -9,6 +9,7 @@ const readline = require('readline').createInterface({
 const util = require('util');
 const path = require('path');
 const os = require('os');
+const URL = require('url').URL;
 
 const get = util.promisify(request.get);
 const post = util.promisify(request.post);


### PR DESCRIPTION
### Problem

As per https://github.com/twitterdev/autohook/issues/16, users can get a `ReferenceError: URL is not defined` when using Autohook

### Solution

Autohook now explicitly requires the `URL` object from Node's `url` library.