### PR TITLE
Expose removeWebhook, getWebhooks, setWebhook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Problem

There is no current way of getting or setting individual webhooks.

### Solution

Expose methods to manage individual webhooks.

### Result

- `removeWebhook` will accept a webhook item as defined from the Twitter GET webhooks payload. The webhook will be removed if it exists.
- `setWebhook` is equivalent to `start` when called with a URL argument.
- `getWebhooks` returns the list of webhooks as defined in the Twitter GET webhooks payload.
