### PR TITLE
fix wrong arg name

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,7 +56,7 @@ const subscribe = async (auth) => {
   }
 
   try {
-    await webhook.start(argv.webhookUrl || null);  
+    await webhook.start(argv.url || null);  
   } catch(e) {
     switch (e.constructor) {
       case TooManyWebhooksError:


### PR DESCRIPTION
### Problem

cli.js `--url` doesn't get pass to `webhook.start` cause `webhook.start` expects `--webhook-url`

### Solution

Make `webhook.start` accepts `url` arg instead

### Result

Make cli.js works when pass along `--url`
