### PR TITLE
Add signature verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-autohook",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Automatically setup and serve webhooks for the Twitter Account Activity API",
   "repository": {
     "type": "git",

--- a/test/signature.js
+++ b/test/signature.js
@@ -1,0 +1,17 @@
+const { validateSignature } = require('../');
+const assert = require('assert');
+const oauth = {
+  consumer_key: 'test',
+  consumer_secret: 'test',
+  token: 'test',
+  token_secret: 'test',
+};
+
+const fixtures = [
+  {body: 'test=1&other_test=2', header: {'x-twitter-webhooks-signature': 'sha256=25Cu3iwbbiqBTwQRzcKJZwisjf736V2Q8UaTlkfLSoc='}},
+  {body: '{"test_number":1,"test_string":"two"}', header: {'x-twitter-webhooks-signature': 'sha256=YWHphPn/JFq43jkF0y4/w8R/SelmLjvpunhVFY8JhlI='}},
+]
+
+for (const {body, header} of fixtures) {
+  assert.ok(validateSignature(header, oauth, body));
+}


### PR DESCRIPTION
### Problem

The optional signature verification is not implemented.

### Solution

This PR adds a `verifySignature` method to compare the signature against the `x-twitter-webhooks-signature` header. This method accepts three arguments:

- An object that must contain a key named `x-twitter-webhooks-signature`
- An object that must contain a key named `consumer_secret`
- A string representing either a query string or a POST body
 

### Result

- When Autohook is used with its built-in server (e.g. from the command line), webhook signatures will be automatically checked
- When Autohook is used with a standalone server, users will be able to use `verifySignature` to verify the request.